### PR TITLE
Add PSL logo to Twitter card

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,6 +3,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:image" content="http://pslmodels.org/imgs/PolicySimLibrary-1000px.png"/>
   {%- seo -%}
   <link rel="stylesheet" href="{{ "/assets/css/style.css" | relative_url }}">
   {%- feed_meta -%}


### PR DESCRIPTION
Adds the PSL logo to the card that is generated when posting a blog link to Twitter:

<img width="534" alt="Screen Shot 2020-12-26 at 11 36 00 AM" src="https://user-images.githubusercontent.com/43755005/103155492-89df0080-476e-11eb-81b1-fe6ec4e2be6e.png">

cc @MaxGhenis 
