### PR TITLE
Remove Demo Day numbers from post titles

### DIFF
--- a/_posts/2020-11-18-demo-day-1-creating-reform-files.md
+++ b/_posts/2020-11-18-demo-day-1-creating-reform-files.md
@@ -4,7 +4,7 @@ layout: post
 description: The first in Policy Simulation Library's new live demo series describes specifying tax reforms.
 categories: [demo-days]
 author: Matt Jensen
-title: "Demo Day 1: Building Policy Reform Files"
+title: "Demo Day: Building Policy Reform Files"
 ---
 
 Check out the video:

--- a/_posts/2020-11-23-demo-day-2-tax-cruncher.md
+++ b/_posts/2020-11-23-demo-day-2-tax-cruncher.md
@@ -4,7 +4,7 @@ layout: post
 description: How to calculate a taxpayer's liabilities under current law and under a policy reform.
 categories: [demo-days, individual-income-tax, tax-cruncher]
 author: Peter Metz
-title: "Demo Day 2: Tax-Cruncher"
+title: "Demo Day: Tax-Cruncher"
 ---
 
 {% include youtube.html content='https://youtu.be/d4T-DOxm2QQ' %}

--- a/_posts/2020-12-03-demo-day-3-cost-of-capital-calculator.md
+++ b/_posts/2020-12-03-demo-day-3-cost-of-capital-calculator.md
@@ -4,7 +4,7 @@
  description: Computing the impact of taxes on business investment incentives under alternative policy scenarios.
  categories: [demo-days, cost-of-capital-calculator, business-taxation, corporate-income-tax]
  author: Jason DeBacker
- title: "Demo Day 3: Cost-of-Capital-Calculator Web Application"
+ title: "Demo Day: Cost-of-Capital-Calculator Web Application"
 ---
 
  {% include youtube.html content='https://youtu.be/KLIuFbYPpNA' %}

--- a/_posts/2020-12-23-demo-day-4-taxbrain.md
+++ b/_posts/2020-12-23-demo-day-4-taxbrain.md
@@ -4,7 +4,7 @@ layout: post
 description: How to use the Tax-Brain web-app
 categories: [demo-days, individual-income-tax, tax-brain]
 author: Anderson Frailey
-title: "Demo Day 4: Tax-Brain"
+title: "Demo Day: Tax-Brain"
 ---
 
  {% include youtube.html content='https://youtu.be/Zc_XEErfO5E' %}

--- a/_posts/2021-01-28-demo-day-5-how-to-use-ogusa.md
+++ b/_posts/2021-01-28-demo-day-5-how-to-use-ogusa.md
@@ -4,7 +4,7 @@ layout: post
 description: How to use OG-USA macroeconomic model of U.S. fiscal policy
 categories: [demo-days, OG-USA, Tax-Calculator, open-source, policy-simulation-library, compute-studio]
 author: Richard W. Evans
-title: "Demo Day 5: How to Use OG-USA Macroeconomic Model of U.S. Fiscal Policy"
+title: "Demo Day: How to Use OG-USA Macroeconomic Model of U.S. Fiscal Policy"
 ---
 
 ![](../images/OG-USA_logo_long.png)

--- a/_posts/2021-01-29-demo-day-6-scf-microdf.md
+++ b/_posts/2021-01-29-demo-day-6-scf-microdf.md
@@ -4,7 +4,7 @@ layout: post
 description: Analyzing US wealth data in a web-based Python notebook
 categories: [demo-days, microdf, scf]
 author: Max Ghenis
-title: "Demo Day 6: Running the scf and microdf Python packages in Google Colab"
+title: "Demo Day: Running the scf and microdf Python packages in Google Colab"
 ---
 
  {% include youtube.html content='https://youtu.be/Zlws_gC9HeY' %}


### PR DESCRIPTION
This preserves them in the URLs so that old URLs don't break, but should we just pull the band-aid off? @jdebacker @MattHJensen 